### PR TITLE
Adding connectors wording to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ of the relationship between different entities in a system:
 **Alternatives:**
 `index` / `detail`
 
+### `male` / `female` (connectors, fasteners)
+
+**Alternatives:**
+`plug` / `socket`
+`plug` / `jack`
+
 ### `blacklist` / `whitelist`
 
 **Alternatives:**


### PR DESCRIPTION
In tech a simple view of genders is used often used when it comes to connectors. Even terms like "mating" tend to describe the connection of plugs to sockets. The assignment is a direct analogy with genitalia and heterosexual intercourse. I added some alternative wording to use.

Fixes #13 